### PR TITLE
Adjust keywords/domains columns

### DIFF
--- a/frontend/src/components/EventsTable.tsx
+++ b/frontend/src/components/EventsTable.tsx
@@ -15,7 +15,7 @@ export const columns: Array<ColumnSpec> = [
     id: "header",
     title: "Header\u2009/\u2009Link",
     render: (event) => (
-      <td className="max-w-50">
+      <td className="max-w-1/2">
         <div>
           {event.header}
           <Link to={`/event/${event.id}`} className="ps-2">
@@ -63,7 +63,7 @@ export const columns: Array<ColumnSpec> = [
     id: "keywords",
     title: "Keywords",
     render: (event) => (
-      <td className="max-w-30">
+      <td className="max-w-32">
         <Keywords keywords={event.keywords} />
       </td>
     ),
@@ -72,7 +72,7 @@ export const columns: Array<ColumnSpec> = [
     id: "domains",
     title: "Domains",
     render: (event) => (
-      <td className="max-w-30">
+      <td className="max-w-32">
         <Keywords keywords={event.hcoe_domains ?? []} />
       </td>
     ),
@@ -80,7 +80,7 @@ export const columns: Array<ColumnSpec> = [
   {
     id: "author",
     title: "Author",
-    render: (event) => <td className="max-w-30">{event.author}</td>,
+    render: (event) => <td className="max-w-32">{event.author}</td>,
   },
 ];
 

--- a/frontend/src/components/Keywords.tsx
+++ b/frontend/src/components/Keywords.tsx
@@ -1,11 +1,11 @@
 export function Keywords({ keywords }: { keywords: string[] }) {
   return (
-    <>
+    <div className="flex flex-wrap gap-0.5">
       {keywords.map((k, i) => (
-        <span className="rounded-sm bg-gray-800 p-1 m-0.5 inline whitespace-nowrap" key={i}>
+        <span className="rounded-sm bg-gray-800 px-1 py-0.5 whitespace-nowrap" key={i}>
           {k}
         </span>
       ))}
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
Fixes #59.

* Actual `max-w`
* Tighter spacing

![Screenshot 2025-01-28 at 15 00 03](https://github.com/user-attachments/assets/4f3d9920-f43c-4c19-9651-5fd52af9af48)
