### PR TITLE
fix: remove create extension postgis

### DIFF
--- a/backend/migrations/1720009709075_create-extension-postgis.cjs
+++ b/backend/migrations/1720009709075_create-extension-postgis.cjs
@@ -9,9 +9,12 @@ exports.shorthands = undefined;
  * @returns {Promise<void> | void}
  */
 exports.up = (pgm) => {
-    pgm.sql(`
-        CREATE EXTENSION IF NOT EXISTS postgis;
-    `);
+    // PostGIS is provisioned outside the application in production environments
+    // such as CloudNativePG, and the app role does not have permission to create
+    // extensions there. The current schema no longer depends on PostGIS types, so
+    // this historical migration is intentionally a no-op.
+
+    // If you need to use PostGIS types, you can create the extension manually with init script elsewhere.
 };
 
 /**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       retries: 5
     volumes:
       - db-data:/var/lib/postgresql/data
+      - ./postgres-init-postgis.sql:/docker-entrypoint-initdb.d/99-create-postgis-extension.sql:ro
       - ./preseed:/tmp
 
   app:

--- a/postgres-init-postgis.sql
+++ b/postgres-init-postgis.sql
@@ -1,0 +1,3 @@
+-- Provision PostGIS during database initialization so the application does not
+-- need CREATE EXTENSION privileges when running migrations.
+CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA public;


### PR DESCRIPTION
This is a pre-requisite for running BattleLog in Kubernetes environment

Changes:
- `backend/migrations/1720009709075_create-extension-postgis.cjs` was disabled
- Add logic for creating the extension elsewhere 

Rationale:
- Until now, Docker Compose runs `CREATE EXTENSION postgis` during set up in file `backend/migrations/1720009709075_create-extension-postgis.cjs` 
- This migration is not needed in Kubernetes setting, because  cloudnative-pg operator handles enabling this extension through and it actually prevented BattleLog in Kubernetes from starting (no db superuser privileges)
- This way BattleLog should not need super user access to the database, it only specifies that it needs postgresql with postgis extension
