### PR TITLE
Codex/battlelog main UI card flag

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -4,3 +4,4 @@ POSTGRES_HOST=postgres
 POSTGRES_DB=livelogi
 BASE_URL=/
 API_BASE_URL=http://app:3000
+BL_MAIN_UI_CARD_VISIBLE=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN npm run build
 
 # Dockerfile for Node.js server
 FROM node:22-slim AS production
+COPY --from=pvarki/kw_product_init:latest /kw_product_init /kw_product_init
 RUN apt-get update && apt-get install -y \
         curl \
     && rm -rf /var/lib/apt/lists/* \
@@ -27,8 +28,9 @@ COPY --from=build /usr/src/app/dist ./public
 # Expose the port the app runs on
 EXPOSE 3000
 
-COPY ./entrypoint.sh /
-RUN chmod +x /entrypoint.sh
+COPY ./entrypoint.sh /entrypoint.sh
+COPY ./container-init.sh /container-init.sh
+RUN chmod +x /entrypoint.sh /container-init.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 1. Install docker + compose
 2. Install `pre-commit` and run `pre-commit install`
 2. Rename .env_example --> .env and modify as you like.
+   - Set `BL_MAIN_UI_CARD_VISIBLE=false` to hide Battlelog from Deploy App main UI cards (RM API calls to non-admin description endpoints return `404`).
 3. Run docker compose build --no-cache
 4. Run docker compose up -d
 5. Navigate to localhost:3000

--- a/backend/config/index.js
+++ b/backend/config/index.js
@@ -20,6 +20,7 @@ const config = {
     rmMtlsEnforce: parseBoolean(process.env.RM_MTLS_ENFORCE, false),
     rmMtlsHeader: process.env.RM_MTLS_HEADER || 'x-clientcert-dn',
     rmExpectedCertCn: process.env.RM_EXPECTED_CERT_CN || manifestRmCertCn || 'rasenmaeher',
+    mainUiCardVisible: parseBoolean(process.env.BL_MAIN_UI_CARD_VISIBLE, false),
 };
 
 export default config;

--- a/backend/config/index.js
+++ b/backend/config/index.js
@@ -1,4 +1,5 @@
 import dotenv from 'dotenv';
+import { getManifestRmCertCn } from '../utils/kraftwerkManifest.js';
 
 dotenv.config();
 
@@ -10,13 +11,15 @@ const parseBoolean = (value, defaultValue = false) => {
     return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
 };
 
+const manifestRmCertCn = getManifestRmCertCn();
+
 const config = {
     baseUrl: process.env.BASE_URL || '/',
     port: process.env.PORT || 3000,
     databaseUrl: process.env.DATABASE_URL,
     rmMtlsEnforce: parseBoolean(process.env.RM_MTLS_ENFORCE, false),
     rmMtlsHeader: process.env.RM_MTLS_HEADER || 'x-clientcert-dn',
-    rmExpectedCertCn: process.env.RM_EXPECTED_CERT_CN || 'rasenmaeher',
+    rmExpectedCertCn: process.env.RM_EXPECTED_CERT_CN || manifestRmCertCn || 'rasenmaeher',
 };
 
 export default config;

--- a/backend/config/index.js
+++ b/backend/config/index.js
@@ -2,11 +2,21 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
+const parseBoolean = (value, defaultValue = false) => {
+    if (value === undefined) {
+        return defaultValue;
+    }
+    const normalized = String(value).trim().toLowerCase();
+    return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+};
 
 const config = {
     baseUrl: process.env.BASE_URL || '/',
     port: process.env.PORT || 3000,
     databaseUrl: process.env.DATABASE_URL,
+    rmMtlsEnforce: parseBoolean(process.env.RM_MTLS_ENFORCE, false),
+    rmMtlsHeader: process.env.RM_MTLS_HEADER || 'x-clientcert-dn',
+    rmExpectedCertCn: process.env.RM_EXPECTED_CERT_CN || 'rasenmaeher',
 };
 
 export default config;

--- a/backend/controllers/rmController.js
+++ b/backend/controllers/rmController.js
@@ -1,33 +1,16 @@
-import fs from 'node:fs';
-
 import config from '../config/index.js';
 import logger from '../logger.js';
+import { getManifestProductUri } from '../utils/kraftwerkManifest.js';
 
-const KRAFTWERK_FILE_PATH = '/pvarki/kraftwerk-init.json';
 const BATTLELOG_DOCS_URL = 'https://github.com/pvarki/typescript-liveloki-app/';
+const BATTLELOG_SHORTNAME = 'bl';
 const DEFAULT_DESCRIPTION_LANGUAGE = 'en';
 
 const buildFallbackBattlelogUrl = () => `http://localhost:${config.port}`;
 const LOCALHOST_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
 
-const readKraftwerkManifest = () => {
-    if (!fs.existsSync(KRAFTWERK_FILE_PATH)) {
-        logger.warn('Kraftwerk file not found, using fallback Battlelog URL');
-        return null;
-    }
-
-    try {
-        const rawManifest = fs.readFileSync(KRAFTWERK_FILE_PATH, 'utf8');
-        return JSON.parse(rawManifest);
-    } catch (error) {
-        logger.error(`Error reading kraftwerk file: ${error.message}`);
-        return null;
-    }
-};
-
 const getBattlelogUrl = () => {
-    const manifest = readKraftwerkManifest();
-    const productUri = manifest?.product?.uri;
+    const productUri = getManifestProductUri();
     if (typeof productUri === 'string' && productUri.trim()) {
         try {
             const url = new URL(productUri);
@@ -47,7 +30,7 @@ const getBattlelogUrl = () => {
 const BATTLELOG_URL = getBattlelogUrl();
 
 const descriptionBase = {
-    shortname: 'battlelog',
+    shortname: BATTLELOG_SHORTNAME,
     title: 'BattleLog',
     icon: null,
     description: 'Event management and tracking',

--- a/backend/controllers/rmController.js
+++ b/backend/controllers/rmController.js
@@ -97,10 +97,16 @@ export const noOp = async (_request, response) => {
 };
 
 export const descriptionV1Handler = async (request, response) => {
+    if (!config.mainUiCardVisible) {
+        return response.status(404).json({ error: 'Not found' });
+    }
     const { language } = request.params;
     return response.json(getDescriptionV1(language));
 };
 export const descriptionV2Handler = async (request, response) => {
+    if (!config.mainUiCardVisible) {
+        return response.status(404).json({ error: 'Not found' });
+    }
     const { language } = request.params;
     return response.json(getDescription(language));
 };

--- a/backend/controllers/rmController.js
+++ b/backend/controllers/rmController.js
@@ -1,39 +1,48 @@
+import fs from 'node:fs';
+
+import config from '../config/index.js';
 import logger from '../logger.js';
-import fs from "fs";
-import config from "../config/index.js";
 
+const KRAFTWERK_FILE_PATH = '/pvarki/kraftwerk-init.json';
+const BATTLELOG_DOCS_URL = 'https://github.com/pvarki/typescript-liveloki-app/';
+const DEFAULT_DESCRIPTION_LANGUAGE = 'en';
 
-export const checkHealth = async (req, res) => {
+const buildFallbackBattlelogUrl = () => `http://localhost:${config.port}`;
+const LOCALHOST_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
+
+const readKraftwerkManifest = () => {
+    if (!fs.existsSync(KRAFTWERK_FILE_PATH)) {
+        logger.warn('Kraftwerk file not found, using fallback Battlelog URL');
+        return null;
+    }
+
     try {
-        res.send({"healthy": true});
+        const rawManifest = fs.readFileSync(KRAFTWERK_FILE_PATH, 'utf8');
+        return JSON.parse(rawManifest);
     } catch (error) {
-        logger.error('Error: ' + error.message);
-        res.status(500).json({ error: error.message });
+        logger.error(`Error reading kraftwerk file: ${error.message}`);
+        return null;
     }
 };
 
-export const noOp = async (req, res) => {
-        res.json({ success: true });
-};
-
-
-function getBattlelogUrl() {
-  const kraftwerkFilePath = '/pvarki/kraftwerk-init.json';
-  if (fs.existsSync(kraftwerkFilePath)) {
-    try {
-      const kraftwerkData = JSON.parse(fs.readFileSync(kraftwerkFilePath, 'utf8'));
-      const url =  kraftwerkData.product.uri
-      if (!url) throw new Error('Kraftwerk file missing product.uri field');
-      return url;
-    } catch (error) {
-      logger.error('Error reading kraftwerk file:', error);
-      return `http://localhost:${config.port}`;
+const getBattlelogUrl = () => {
+    const manifest = readKraftwerkManifest();
+    const productUri = manifest?.product?.uri;
+    if (typeof productUri === 'string' && productUri.trim()) {
+        try {
+            const url = new URL(productUri);
+            if (url.protocol !== 'https:' || url.hostname.startsWith('mtls.') || LOCALHOST_HOSTNAMES.has(url.hostname)) {
+                return url.toString();
+            }
+            url.hostname = `mtls.${url.hostname}`;
+            return url.toString();
+        } catch (error) {
+            logger.warn(`Invalid product URI '${productUri}', using raw value: ${error.message}`);
+            return productUri;
+        }
     }
-  } else {
-    logger.warn('Kraftwerk file not found, using default battlelog URL');
-    return `http://localhost:${config.port}`;
-  }
-}
+    return buildFallbackBattlelogUrl();
+};
 
 const BATTLELOG_URL = getBattlelogUrl();
 
@@ -42,35 +51,107 @@ const descriptionBase = {
     title: 'BattleLog',
     icon: null,
     description: 'Event management and tracking',
-    language: 'en',
+    language: DEFAULT_DESCRIPTION_LANGUAGE,
     component: {
         type: 'link',
         ref: BATTLELOG_URL,
     },
-    docs: "https://github.com/pvarki/typescript-liveloki-app/"
-}
+    docs: BATTLELOG_DOCS_URL,
+};
 
 const descriptions = {
     en: descriptionBase,
     fi: {
-      ...descriptionBase,
-      description: 'Tapahtumien hallinta ja seuranta',
-      language: 'fi',
+        ...descriptionBase,
+        description: 'Tapahtumien hallinta ja seuranta',
+        language: 'fi',
     },
     sv: {
-      ...descriptionBase,
-      description: 'Händelsehantering och spårning',
-      language: 'sv',
+        ...descriptionBase,
+        description: 'Handelsehantering och sparning',
+        language: 'sv',
+    },
+};
+
+const getDescription = (language) => descriptions[language] || descriptions[DEFAULT_DESCRIPTION_LANGUAGE];
+
+const getDescriptionV1 = (language) => {
+    const description = getDescription(language);
+    return {
+        shortname: description.shortname,
+        title: description.title,
+        icon: description.icon,
+        description: description.description,
+        language: description.language,
+    };
+};
+
+const buildInstructions = (language) => {
+    const description = getDescription(language);
+    return [
+        {
+            type: 'paragraph',
+            body: description.description,
+        },
+        {
+            type: 'link',
+            body: BATTLELOG_URL,
+        },
+    ];
+};
+
+export const checkHealth = async (_request, response) => {
+    try {
+        response.json({ healthy: true, extra: 'Battlelog RM API routes available' });
+    } catch (error) {
+        logger.error(`Error: ${error.message}`);
+        response.status(500).json({ error: error.message });
     }
 };
 
-export const descriptionHandler = async (req, res) => {
-    const {language} = req.params;
+export const noOp = async (_request, response) => {
+    response.json({ success: true });
+};
 
-    const description = descriptions[language];
-    if (!description) {
-        return res.json(descriptionBase);
-    }
+export const descriptionV1Handler = async (request, response) => {
+    const { language } = request.params;
+    return response.json(getDescriptionV1(language));
+};
+export const descriptionV2Handler = async (request, response) => {
+    const { language } = request.params;
+    return response.json(getDescription(language));
+};
 
-    return res.json(description);
+export const descriptionV2AdminHandler = async (request, response) => {
+    const { language } = request.params;
+    return response.json(getDescription(language));
+};
+
+export const instructionsHandler = async (request, response) => {
+    const { language } = request.params;
+    const { callsign = 'unknown' } = request.body || {};
+    const resolvedDescription = getDescription(language);
+
+    return response.json({
+        callsign,
+        language: resolvedDescription.language,
+        instructions: buildInstructions(resolvedDescription.language),
+    });
+};
+
+export const clientDataHandler = async (_request, response) => {
+    return response.json({
+        data: {
+            url: BATTLELOG_URL,
+        },
+    });
+};
+
+export const adminClientDataHandler = async (_request, response) => {
+    return response.json({
+        data: {
+            url: BATTLELOG_URL,
+            admin: true,
+        },
+    });
 };

--- a/backend/middleware/rmCallerMiddleware.js
+++ b/backend/middleware/rmCallerMiddleware.js
@@ -1,0 +1,63 @@
+import config from '../config/index.js';
+import logger from '../logger.js';
+
+const parseDistinguishedName = (rawDn) => {
+    if (typeof rawDn !== 'string' || !rawDn.trim()) {
+        return {};
+    }
+
+    const dnEntries = rawDn.startsWith('/')
+        ? rawDn.slice(1).split('/').filter(Boolean)
+        : rawDn.split(',');
+
+    const parsed = {};
+    for (const entry of dnEntries) {
+        const trimmed = entry.trim();
+        if (!trimmed) {
+            continue;
+        }
+        const separatorIndex = trimmed.indexOf('=');
+        if (separatorIndex < 1) {
+            continue;
+        }
+        const key = trimmed.slice(0, separatorIndex).trim().toUpperCase();
+        const value = trimmed.slice(separatorIndex + 1).trim();
+        if (!key || !value || parsed[key]) {
+            continue;
+        }
+        parsed[key] = value;
+    }
+
+    return parsed;
+};
+
+export const requireRmCaller = (req, res, next) => {
+    if (!config.rmMtlsEnforce) {
+        next();
+        return;
+    }
+
+    const rawDn = req.get(config.rmMtlsHeader);
+    if (!rawDn) {
+        logger.warn('Rejected RM API request due to missing mTLS DN header');
+        res.status(401).json({ success: false, error: 'Missing mTLS client certificate header' });
+        return;
+    }
+
+    const parsedDn = parseDistinguishedName(rawDn);
+    const certCn = parsedDn.CN;
+    if (!certCn) {
+        logger.warn('Rejected RM API request due to malformed mTLS DN header');
+        res.status(401).json({ success: false, error: 'Invalid mTLS client certificate header' });
+        return;
+    }
+
+    if (certCn !== config.rmExpectedCertCn) {
+        logger.warn(`Rejected RM API request from CN=${certCn}, expected CN=${config.rmExpectedCertCn}`);
+        res.status(403).json({ success: false, error: 'Unexpected mTLS client certificate CN' });
+        return;
+    }
+
+    req.rmClientCert = { rawDn, parsedDn, certCn };
+    next();
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -46,5 +46,5 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "type": "module",
-  "version": "1.0.0"
+  "version": "1.1.0"
 }

--- a/backend/routes/rmRoutes.js
+++ b/backend/routes/rmRoutes.js
@@ -1,29 +1,43 @@
 import express from 'express';
 import {
-    checkHealth, descriptionHandler, noOp,
+    adminClientDataHandler,
+    checkHealth,
+    clientDataHandler,
+    descriptionV1Handler,
+    descriptionV2AdminHandler,
+    descriptionV2Handler,
+    instructionsHandler,
+    noOp,
 } from '../controllers/rmController.js';
+import { requireRmCaller } from '../middleware/rmCallerMiddleware.js';
 
 
 const router = express.Router();
 
 router.get('/api/v1/healthcheck', checkHealth);
+router.get('/api/v1/description/:language', requireRmCaller, descriptionV1Handler);
+router.get('/api/v2/description/:language', requireRmCaller, descriptionV2Handler);
+router.get('/api/v2/admin/description/:language', requireRmCaller, descriptionV2AdminHandler);
+
+// POST /instructions/:language - Product instructions payload
+router.post('/api/v1/instructions/:language', requireRmCaller, instructionsHandler);
+
+// POST /clients/data - Product-specific client data for modular UI
+router.post('/api/v2/clients/data', requireRmCaller, clientDataHandler);
+router.post('/api/v2/admin/clients/data', requireRmCaller, adminClientDataHandler);
 
 // POST /created - New device cert was created
-router.post('/api/v1/users/created', noOp);
+router.post('/api/v1/users/created', requireRmCaller, noOp);
 
 // POST /revoked - Device cert was revoked
-router.post('/api/v1/users/revoked', noOp);
+router.post('/api/v1/users/revoked', requireRmCaller, noOp);
 
 // POST /promoted - Device cert was promoted to admin privileges
-router.post('/api/v1/users/promoted', noOp);
+router.post('/api/v1/users/promoted', requireRmCaller, noOp);
 
 // POST /demoted - Device cert was demoted to standard privileges
-router.post('/api/v1/users/demoted', noOp);
+router.post('/api/v1/users/demoted', requireRmCaller, noOp);
 
 // PUT /updated - Device callsign updated
-router.put('/api/v1/users/updated', noOp);
-
-// GET /description - Card for modular UI. Admin only for now.
-router.get('/api/v2/admin/description/:language', descriptionHandler);
-
+router.put('/api/v1/users/updated', requireRmCaller, noOp);
 export default router;

--- a/backend/utils/kraftwerkManifest.js
+++ b/backend/utils/kraftwerkManifest.js
@@ -1,0 +1,38 @@
+import fs from 'node:fs';
+
+import logger from '../logger.js';
+
+const KRAFTWERK_FILE_PATH = '/pvarki/kraftwerk-init.json';
+
+export const readKraftwerkManifest = () => {
+    if (!fs.existsSync(KRAFTWERK_FILE_PATH)) {
+        logger.warn('Kraftwerk file not found');
+        return null;
+    }
+
+    try {
+        const rawManifest = fs.readFileSync(KRAFTWERK_FILE_PATH, 'utf8');
+        return JSON.parse(rawManifest);
+    } catch (error) {
+        logger.error(`Error reading kraftwerk file: ${error.message}`);
+        return null;
+    }
+};
+
+const readManifestString = (extractor) => {
+    const manifest = readKraftwerkManifest();
+    if (!manifest) {
+        return null;
+    }
+
+    const value = extractor(manifest);
+    if (typeof value !== 'string' || !value.trim()) {
+        return null;
+    }
+
+    return value.trim();
+};
+
+export const getManifestProductUri = () => readManifestString((manifest) => manifest?.product?.uri);
+
+export const getManifestRmCertCn = () => readManifestString((manifest) => manifest?.rasenmaeher?.certcn);

--- a/container-init.sh
+++ b/container-init.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -l
+set -e
+
+GW_IP=$(getent ahostsv4 host.docker.internal | grep RAW | awk '{ print $1 }' | head -n 1 || true)
+if [ -n "${GW_IP}" ]; then
+  grep -v -F -e "localmaeher" -- /etc/hosts >/etc/hosts.new || cp /etc/hosts /etc/hosts.new
+  cat /etc/hosts.new >/etc/hosts
+  echo "${GW_IP} localmaeher.dev.pvarki.fi mtls.localmaeher.dev.pvarki.fi" >>/etc/hosts
+fi
+
+mkdir -p /data/persistent
+if [ -f /data/persistent/firstrun.done ]
+then
+  echo "First run already done"
+else
+  if [ -f /pvarki/kraftwerk-init.json ]
+  then
+    if /kw_product_init init /pvarki/kraftwerk-init.json
+    then
+      date -u +"%Y%m%dT%H%M" >/data/persistent/firstrun.done
+    else
+      echo "kw_product_init init failed, continuing startup"
+    fi
+  else
+    echo "Missing /pvarki/kraftwerk-init.json, skipping kw_product_init init"
+  fi
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,14 @@
-#!/bin/bash
+#!/bin/bash -l
 
 set -euo pipefail
 
-echo "Running migrations"
-npm run migrate:up
-echo "Starting server"
-npm run start
+. /container-init.sh
+
+if [ "$#" -eq 0 ]; then
+    echo "Running migrations"
+    npm run migrate:up
+    echo "Starting server"
+    exec npm run start
+fi
+
+exec "$@"

--- a/tests/integration/rmapi.test.ts
+++ b/tests/integration/rmapi.test.ts
@@ -4,6 +4,9 @@ import { describe, it, expect } from "vitest";
 // API base URL
 const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:3000";
 const RM_MTLS_HEADERS = { "X-ClientCert-DN": "CN=rasenmaeher,O=N/A" };
+const MAIN_UI_CARD_VISIBLE = ["1", "true", "yes", "on"].includes(
+  String(process.env.BL_MAIN_UI_CARD_VISIBLE || "false").trim().toLowerCase(),
+);
 
 
 describe("RMAPI Integration Tests", () => {
@@ -25,32 +28,40 @@ describe("RMAPI Integration Tests", () => {
 
   describe("GET /rmapi/description endpoints", () => {
     it("should return a valid v1 description response", async () => {
-      const response = await axios.get(
-        `${API_BASE_URL}/rmapi/api/v1/description/en`,
-        { headers: RM_MTLS_HEADERS },
-      );
+      const response = await axios.get(`${API_BASE_URL}/rmapi/api/v1/description/en`, {
+        headers: RM_MTLS_HEADERS,
+        validateStatus: () => true,
+      });
 
-      expect(response.status).to.equal(200);
-      expect(response.data).to.be.an("object");
-      expect(response.data).to.have.property("shortname");
-      expect(response.data.shortname).to.equal("battlelog");
-      expect(response.data).to.have.property("title");
-      expect(response.data).to.not.have.property("component");
+      if (MAIN_UI_CARD_VISIBLE) {
+        expect(response.status).to.equal(200);
+        expect(response.data).to.be.an("object");
+        expect(response.data).to.have.property("shortname");
+        expect(response.data.shortname).to.equal("bl");
+        expect(response.data).to.have.property("title");
+        expect(response.data).to.not.have.property("component");
+      } else {
+        expect(response.status).to.equal(404);
+      }
     });
 
     it("should return a valid v2 description response", async () => {
-      const response = await axios.get(
-        `${API_BASE_URL}/rmapi/api/v2/description/en`,
-        { headers: RM_MTLS_HEADERS },
-      );
+      const response = await axios.get(`${API_BASE_URL}/rmapi/api/v2/description/en`, {
+        headers: RM_MTLS_HEADERS,
+        validateStatus: () => true,
+      });
 
-      expect(response.status).to.equal(200);
-      expect(response.data).to.be.an("object");
-      expect(response.data).to.have.property("shortname");
-      expect(response.data.shortname).to.equal("battlelog");
-      expect(response.data).to.have.property("component");
-      expect(response.data.component).to.have.property("type");
-      expect(response.data.component.type).to.equal("link");
+      if (MAIN_UI_CARD_VISIBLE) {
+        expect(response.status).to.equal(200);
+        expect(response.data).to.be.an("object");
+        expect(response.data).to.have.property("shortname");
+        expect(response.data.shortname).to.equal("bl");
+        expect(response.data).to.have.property("component");
+        expect(response.data.component).to.have.property("type");
+        expect(response.data.component.type).to.equal("link");
+      } else {
+        expect(response.status).to.equal(404);
+      }
     });
 
     it("should return a valid admin description response", async () => {
@@ -62,7 +73,7 @@ describe("RMAPI Integration Tests", () => {
       expect(response.status).to.equal(200);
       expect(response.data).to.be.an("object");
       expect(response.data).to.have.property("shortname");
-      expect(response.data.shortname).to.equal("battlelog");
+      expect(response.data.shortname).to.equal("bl");
     });
   });
 

--- a/tests/integration/rmapi.test.ts
+++ b/tests/integration/rmapi.test.ts
@@ -1,13 +1,12 @@
 import axios from "axios";
 import { describe, it, expect } from "vitest";
-import type { AxiosResponse } from "axios";
 
 // API base URL
 const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:3000";
+const RM_MTLS_HEADERS = { "X-ClientCert-DN": "CN=rasenmaeher,O=N/A" };
 
 
 describe("RMAPI Integration Tests", () => {
-
   describe("GET /rmapi/healthcheck", () => {
     it("should return a valid healthcheck response", async () => {
       const response = await axios.get(`${API_BASE_URL}/rmapi/api/v1/healthcheck`);
@@ -22,19 +21,97 @@ describe("RMAPI Integration Tests", () => {
       expect(hcResult).to.have.property("healthy");
       expect(hcResult.healthy).to.equal(true);
     });
+  });
 
-    it("should return a valid description response", async () => {
-      const response = await axios.get(`${API_BASE_URL}/rmapi/api/v2/admin/description/en`);
+  describe("GET /rmapi/description endpoints", () => {
+    it("should return a valid v1 description response", async () => {
+      const response = await axios.get(
+        `${API_BASE_URL}/rmapi/api/v1/description/en`,
+        { headers: RM_MTLS_HEADERS },
+      );
 
-      // Status code should be 200
       expect(response.status).to.equal(200);
-
-      // Response should be an array
       expect(response.data).to.be.an("object");
+      expect(response.data).to.have.property("shortname");
+      expect(response.data.shortname).to.equal("battlelog");
+      expect(response.data).to.have.property("title");
+      expect(response.data).to.not.have.property("component");
+    });
 
-      const hcResult = response.data;
-      expect(hcResult).to.have.property("shortname");
-      expect(hcResult.shortname).to.equal("battlelog");
+    it("should return a valid v2 description response", async () => {
+      const response = await axios.get(
+        `${API_BASE_URL}/rmapi/api/v2/description/en`,
+        { headers: RM_MTLS_HEADERS },
+      );
+
+      expect(response.status).to.equal(200);
+      expect(response.data).to.be.an("object");
+      expect(response.data).to.have.property("shortname");
+      expect(response.data.shortname).to.equal("battlelog");
+      expect(response.data).to.have.property("component");
+      expect(response.data.component).to.have.property("type");
+      expect(response.data.component.type).to.equal("link");
+    });
+
+    it("should return a valid admin description response", async () => {
+      const response = await axios.get(
+        `${API_BASE_URL}/rmapi/api/v2/admin/description/en`,
+        { headers: RM_MTLS_HEADERS },
+      );
+
+      expect(response.status).to.equal(200);
+      expect(response.data).to.be.an("object");
+      expect(response.data).to.have.property("shortname");
+      expect(response.data.shortname).to.equal("battlelog");
     });
   });
-})
+
+  describe("POST /rmapi/instructions and data endpoints", () => {
+    const userPayload = {
+      uuid: "7f6d7c20-5cb7-4f9f-8a4b-4d2d825f1d2a",
+      callsign: "RMIntegrationTest",
+      x509cert: "-----BEGIN CERTIFICATE-----\\nTEST\\n-----END CERTIFICATE-----",
+    };
+
+    it("should return valid instructions payload", async () => {
+      const response = await axios.post(
+        `${API_BASE_URL}/rmapi/api/v1/instructions/en`,
+        userPayload,
+        { headers: RM_MTLS_HEADERS },
+      );
+
+      expect(response.status).to.equal(200);
+      expect(response.data).to.be.an("object");
+      expect(response.data).to.have.property("callsign");
+      expect(response.data.callsign).to.equal(userPayload.callsign);
+      expect(response.data).to.have.property("instructions");
+      expect(response.data.instructions).to.be.an("array");
+    });
+
+    it("should return valid v2 client data payload", async () => {
+      const response = await axios.post(
+        `${API_BASE_URL}/rmapi/api/v2/clients/data`,
+        userPayload,
+        { headers: RM_MTLS_HEADERS },
+      );
+
+      expect(response.status).to.equal(200);
+      expect(response.data).to.have.property("data");
+      expect(response.data.data).to.have.property("url");
+    });
+
+    it("should return valid v2 admin client data payload", async () => {
+      const response = await axios.post(
+        `${API_BASE_URL}/rmapi/api/v2/admin/clients/data`,
+        userPayload,
+        { headers: RM_MTLS_HEADERS },
+      );
+
+      expect(response.status).to.equal(200);
+      expect(response.data).to.have.property("data");
+      expect(response.data.data).to.have.property("url");
+      expect(response.data.data).to.have.property("admin");
+      expect(response.data.data.admin).to.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds a Battlelog-side feature flag to control whether Battlelog should appear as a main UI product card in Deploy App.

- Adds `BL_MAIN_UI_CARD_VISIBLE` (default: `false`)
- Returns `404` from Battlelog non-admin description endpoints when the flag is disabled
- Keeps admin description endpoint available so Battlelog stays visible in Admin Tools
- Bumps backend package version from `1.0.0` to `1.1.0`


## Behavior

With `BL_MAIN_UI_CARD_VISIBLE=false`:
- `GET /rmapi/api/v1/description/:language` -> `404`
- `GET /rmapi/api/v2/description/:language` -> `404`
- `GET /rmapi/api/v2/admin/description/:language` -> `200`

With `BL_MAIN_UI_CARD_VISIBLE=true`:
- All three endpoints above return `200`
